### PR TITLE
Add Missing Error-Handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,12 @@ module.exports = function (app) {
 
         // Directory to scan for routes
         loaddir(settings.directory).forEach(function (file) {
-            var controller = require(file);
+            try {
+                var controller = require(file);
+            } catch(e) {
+                console.log(e.trace);
+                process.exit(1);
+            }
             if (typeof controller === 'function' && controller.length === 1) {
                 controller(app);
             }


### PR DESCRIPTION
Currently when you try to enrouten a file that has some bad JavaScript, you get a pretty measily error message:
`[ReferenceError: server is not defined]`

With this change you get a message similar to the message one would get with node.js:

```
ReferenceError: server is not defined
    at Object.<anonymous> (/Users/jamuferguson/dev/paypal/8ballUI/controllers/extendSession.js:26:1)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /Users/jamuferguson/dev/paypal/8ballUI/node_modules/kraken-js/node_modules/express-enrouten/index.js:85:35
    at Array.forEach (native)
    at Object.withRoutes (/Users/jamuferguson/dev/paypal/8ballUI/node_modules/kraken-js/node_modules/express-enrouten/index.js:83:41)
```
