### PR TITLE
Reorder after scan to support late registration of middleware.

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,9 +118,13 @@ module.exports = function (app) {
             // Remove sacrificial express app
             app.stack.pop();
 
+            scan(app, settings);
+
             // Reorganize stack to place router in correct place
             // This could get out of whack if someone registers
-            // directly against express prior to calling enrouten
+            // directly against express prior to calling enrouten.
+            // This is done *after* scanning so any middleware registered
+            // during scanning is correctly put before the router.
             app.stack.some(function (middleware, idx, stack) {
                 if (middleware.handle.name === 'router') {
                     stack.splice(idx, 1);
@@ -129,8 +133,6 @@ module.exports = function (app) {
                 }
                 return false;
             });
-
-            scan(app, settings);
         };
     }
 

--- a/test/enroute.js
+++ b/test/enroute.js
@@ -154,6 +154,33 @@ describe('express-enrouten', function () {
                     next();
                 });
 
+
+                it('should do reordering after scanning to allow scanned files to register middleware', function (next) {
+                    var app;
+
+                    // XXX: This test is only applicable for new implementation/API.
+                    if (fn.name !== 'refactor') {
+                        next();
+                        return;
+                    }
+
+                    app = express();
+                    app.get('/', noop);
+                    app.use(express.static('./public'));
+
+                    fn(app, {
+                        directory: path.join('.', 'fixtures', 'middleware')
+                    });
+
+                    assert.equal(app.stack.length, 5);
+                    assert.equal(app.stack[4].handle.name, 'router');
+
+                    get(app, '/foo', function (err) {
+                        assert.ok(!err);
+                        next();
+                    });
+                });
+
             });
 
 

--- a/test/fixtures/middleware/late-registration.js
+++ b/test/fixtures/middleware/late-registration.js
@@ -1,0 +1,19 @@
+'use strict';
+
+
+module.exports = function (app) {
+
+    app.use('/foo', function (req, res, next) {
+        req.foo = true;
+        next();
+    });
+
+    app.get('/foo', function (req, res) {
+        if (req.foo) {
+            res.send(200, 'ok');
+            return;
+        }
+        res.send(500, 'not ok');
+    });
+
+};


### PR DESCRIPTION
Previously, reordering of middleware to place routes in a predicable location didn't take into account late registration of middleware. For example, prior to this change if a scanned file did the following, the middleware would be placed AFTER the route handler in the middleware stack. This change ensures it is placed before express' router. Includes test case.

``` javascript
// file1.js
module.exports = function (app) {
    app.use('/foo', myMiddleware);
    app.get('/foo', function (req, res, next) {
        res.send('ok');
    }
};
```
