### PR TITLE
Special-case index files to be "/" and not "/index"

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,16 +142,17 @@ function directory(basedir, ancestors, current, fn) {
  */
 function createFileHandler(router) {
     return function handler(basedir, ancestors, current) {
-        var abs, impl, mountPoint, child;
+        var abs, impl, filename, mountPoint, child;
 
         abs = path.join(basedir, ancestors, current);
+        filename = path.basename(current, path.extname(current));
 
         if (isFileModule(abs)) {
             impl = require(abs);
 
             if (typeof impl === 'function' && impl.length === 1) {
                 mountPoint = ancestors ? ancestors.split(path.sep) : [];
-                mountPoint.push(path.basename(current, path.extname(current)));
+                filename !== 'index' && mountPoint.push(filename);
                 mountPoint = '/' + mountPoint.join('/');
 
                 debug('mounting', current, 'at', mountPoint);

--- a/test/enrouten.js
+++ b/test/enrouten.js
@@ -89,7 +89,6 @@ function run(test, name, mount, fn) {
         t.test('nested', function (t) {
             var app, settings;
 
-
             app = express();
             settings = {
                 directory: path.join('fixtures', 'nested')
@@ -100,6 +99,26 @@ function run(test, name, mount, fn) {
             get(app, mount + '/controller', function (err) {
                 t.error(err);
                 get(app, mount + '/subdirectory/subcontroller', function (err) {
+                    t.error(err);
+                    t.end();
+                });
+            });
+        });
+
+
+        t.test('index', function (t) {
+            var app, settings;
+
+            app = express();
+            settings = {
+                directory: path.join('fixtures', 'indexed')
+            };
+
+            fn(app, settings);
+
+            get(app, mount + '/good', function (err) {
+                t.error(err);
+                get(app, mount + '/subgood', function (err) {
                     t.error(err);
                     t.end();
                 });


### PR DESCRIPTION
Fix for issue #25 which treats directory index files as root path (`/`), break ing the convention established by the new API which would've made it `/index`.
