### PR TITLE
fix directory.js to use the correct mountpath

### DIFF
--- a/lib/directory.js
+++ b/lib/directory.js
@@ -69,7 +69,7 @@ function createFileHandler(router) {
                 debug('mounting', current, 'at', mountpath);
                 subrouter = registry(mountpath, router);
                 impl(subrouter);
-                router.use(mountpath, subrouter._router);
+                router.use(subrouter._router);
             }
         }
     };


### PR DESCRIPTION
When using directory option, all the routes were being mounted on with their base route being relative to their physical path. I just removed this to use the router directly. 

I can try including some tests for it. I just really haven't gotten around the way the tests are written in this project.
