### PR TITLE
Make app.locals.enrouten nonemunerable.

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,20 +61,28 @@ function mount(app, options) {
         }
 
         // Setup app locals for use in handlers.
-        parent.locals.enrouten = {
+        // Do this way because app.locals has no prototype. One question this raises is,
+        // should an app be able to use enrouten multiple times, and if so, should
+        // app.locals.enrouten routes be merged?
+        // https://github.com/visionmedia/express/blob/6775658ed5cbac13f2d24c89e23ed967ad6a66ba/lib/application.js#L68
+        if (!Object.prototype.hasOwnProperty.call(parent.locals, 'enrouten')) {
+            Object.defineProperty(parent.locals, 'enrouten', {
+                value: {
 
-            routes: router.routes,
+                    routes: router.routes,
 
-            path: function path(name, data) {
-                var route;
-                route = this.routes[name];
-                if (typeof route === 'string') {
-                    return reverend(route, data || {});
+                    path: function path(name, data) {
+                        var route;
+                        route = this.routes[name];
+                        if (typeof route === 'string') {
+                            return reverend(route, data || {});
+                        }
+                        return undefined;
+                    }
+
                 }
-                return undefined;
-            }
-
-        };
+            });
+        }
 
         debug('mounting routes at', app.mountpath);
         debug(router.routes);

--- a/test/enrouten.js
+++ b/test/enrouten.js
@@ -39,7 +39,7 @@ function run(test, name, mount, fn) {
         app = express();
         fn(app);
 
-        fn(app, { basedir: path.join(__dirname, 'fixtures') })
+        fn(app, { basedir: path.join(__dirname, 'fixtures') });
         fn(app, { directory: null });
         fn(app, { index: null });
         fn(app, { routes: null });


### PR DESCRIPTION
During `res.render`, `app.locals` is merged into `res.locals`, but `enrouten` shouldn't be merge with everything else. Making the `enrouten` property nonenumerable to defend against copying.
