### PR TITLE
Revert change to make enrouten non-enumerable.

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,28 +61,20 @@ function mount(app, options) {
         }
 
         // Setup app locals for use in handlers.
-        // Do this way because app.locals has no prototype. One question this raises is,
-        // should an app be able to use enrouten multiple times, and if so, should
-        // app.locals.enrouten routes be merged?
-        // https://github.com/visionmedia/express/blob/6775658ed5cbac13f2d24c89e23ed967ad6a66ba/lib/application.js#L68
-        if (!Object.prototype.hasOwnProperty.call(parent.locals, 'enrouten')) {
-            Object.defineProperty(parent.locals, 'enrouten', {
-                value: {
+        parent.locals.enrouten = {
 
-                    routes: router.routes,
+            routes: router.routes,
 
-                    path: function path(name, data) {
-                        var route;
-                        route = this.routes[name];
-                        if (typeof route === 'string') {
-                            return reverend(route, data || {});
-                        }
-                        return undefined;
-                    }
-
+            path: function path(name, data) {
+                var route;
+                route = this.routes[name];
+                if (typeof route === 'string') {
+                    return reverend(route, data || {});
                 }
-            });
-        }
+                return undefined;
+            }
+
+        };
 
         debug('mounting routes at', app.mountpath);
         debug(router.routes);

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -47,7 +47,7 @@ function traverse(basedir, ancestors, current, fn) {
  * for the desired API `function(router)`, determines mount
  * point and mounts the router.
  * @param router the express Router against which child routers are mounted
- * @returns {Function} the implementation function to provide to directory
+ * @returns {Function} the implementation function to provide to direc`tory
  */
 function createFileHandler(router) {
 


### PR DESCRIPTION
This was a breaking, not-backward compatible change (obviously, in hindsight). Fixing for version 1.1.1
