### PR TITLE
Directory mode: process files with index.js before all others

### DIFF
--- a/lib/directory.js
+++ b/lib/directory.js
@@ -3,85 +3,33 @@
 var fs = require('fs');
 var path = require('path');
 var registry = require('./registry');
+var routeify = require('./routeify');
 var debug = require('debuglog')('enrouten/directory');
 
+module.exports = function directory(router, basedir, routerOptions) {
+    var routes, options;
 
-module.exports = function directory(router, basedir, options) {
-    var handler;
-    handler = createFileHandler(router, options);
-    traverse(basedir, '', '', handler);
-    return router;
-};
-
-
-/**
- * Traverses the provided basedir, invoking the provided function when a file
- * is encountered.
- * @param basedir the root directory where the traversal should begin
- * @param ancesors the relative path from the basedir to the current dir
- * @param current the current directory name
- * @param fn the function to invoke when a file is encountered: `function (basedir, ancestors, current)`
- */
-function traverse(basedir, ancestors, current, fn) {
-    var abs, stat;
-
-    // don't do anything with dot files/directories
-    if (current.charAt(0) === '.') {
-      return;
-    }
-
-    abs = path.join(basedir, ancestors, current);
-    stat = fs.statSync(abs);
-
-    if (stat.isDirectory()) {
-        ancestors = ancestors ? path.join(ancestors, current) : current;
-        fs.readdirSync(abs).forEach(function (child) {
-            traverse(basedir, ancestors, child, fn);
-        });
-    }
-
-    if (stat.isFile()) {
-        fn(basedir, ancestors, current);
-    }
-}
-
-
-/**
- * Factory function that produces a fn implementation to
- * provide to the directory handler. Filters file/module
- * for the desired API `function(router)`, determines mount
- * point and mounts the router.
- * @param router the express Router against which child routers are mounted
- * @param options the options object to pass to each express Router created
- * @returns {Function} the implementation function to provide to direc`tory
- */
-function createFileHandler(router, options) {
-
-    return function handler(basedir, ancestors, current) {
-        var abs, impl, filename, mountpath, subrouter;
-
-        abs = path.join(basedir, ancestors, current);
-        filename = path.basename(current, path.extname(current));
-
-        if (hasRequireHandler(abs)) {
-            impl = require(abs);
-
-            if (typeof impl === 'function' && impl.length === 1) {
-                // Build current pount path, ignoring `index` in lieu of `/`
-                mountpath = ancestors ? ancestors.split(path.sep) : [];
-                filename !== 'index' && mountpath.push(filename);
-                mountpath = '/' + mountpath.join('/');
-
-                debug('mounting', current, 'at', mountpath);
-                subrouter = registry(mountpath, router, options);
-                impl(subrouter);
-                router.use(mountpath, subrouter._router);
-            }
-        }
+    options = {
+        fileChooser: hasRequireHandler
     };
 
-}
+    routes = routeify(basedir, options);
+    Object.keys(routes).forEach(function (mountpath) {
+        var impl, filename, subrouter;
 
+        filename = routes[mountpath];
+        impl = require(pathToModuleId(filename));
+            
+        if (typeof impl === 'function' && impl.length === 1) {
+            debug('mounting', filename, 'at', mountpath);
+            subrouter = registry(mountpath, router, routerOptions);
+            impl(subrouter);
+            router.use(mountpath, subrouter._router);
+        }
+    });
+
+    return router;
+}
 
 /**
  * Returns true if `require` is has a handler for this type
@@ -91,7 +39,33 @@ function createFileHandler(router, options) {
  * @returns {boolean}
  */
 function hasRequireHandler(file) {
-    var fileExt = path.extname(file);
-    var extensions = Object.keys(require.extensions);
-    return !!~extensions.indexOf(fileExt);
+    var ext = path.extname(file);
+
+    // Omit dotfiles
+    // NOTE: Temporary fix in lieu of more complete (cross platform)
+    // fix using file flags/attributes.
+    if (path.basename(file, ext)[0] === '.') {
+        return false;
+    }
+
+    try {
+        // remove the file extension and use require.resolve to resolve known
+        // file types eg. CoffeeScript. Will throw if not found/loadable by node.
+        file = ext ? file.slice(0, -ext.length) : file;
+        require.resolve(file);
+        return true;
+    } catch (err) {
+        return false;
+    }
+}
+
+/**
+ * Gets a module ID from a path suitable for `require()`
+ * @param pathname the path to a file which should be required.
+ * @returns {String} an appropriate module ID for `require()`
+ */
+function pathToModuleId(pathname) {
+    var ext = path.extname(pathname);
+    var moduleId = ext ? pathname.slice(0, -ext.length) : pathname;
+    return moduleId;
 }

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -58,6 +58,11 @@ module.exports = function create(mountpath, router, options) {
     }
 
     mountpath = mountpath || '/';
+    // mergeParams is required if the mount path includes a parameter
+    if (mountpath.indexOf(':') >= 0) {
+        options = options || {};
+        options.mergeParams = true;
+    }
     router = router || new express.Router(options);
 
     registry.routes = routes || Object.create(null);

--- a/lib/routeify.js
+++ b/lib/routeify.js
@@ -1,0 +1,140 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+/* EXAMPLE:
+ * var routes = routeify('./controllers');
+ * Object.keys(routes).forEach(function (fn) {
+ * console.log('%s => %s', fn, routes[fn]);
+ * });
+ * 
+ * Looks like:
+ * 
+ * controllers/index.js => /
+ * controllers/companies/{company}.js => /companies/{company}
+ * controllers/products/{product}/update.js => /products/{product}/update
+ * controllers/products/{product}.js => /products/{product}
+ * controllers/suppliers/{supplier}/index.js => /suppliers/{supplier}
+ * controllers/users/index.js => /users
+ * controllers/users/{user}.js => /users/{user}
+ *
+ *
+ *
+ * `routeify.mapDirectory()` supports an `options` argument too:
+ *
+ * [options.excludeDotFiles] {Boolean}  Excludes dotfiles as well (default: false)
+ * [options.fileChooser]     {Function} Function of the form `function (filename)`
+ *                                      which must return a {Boolean} value indicating
+ *                                      whether the file should be mapped to a route.
+ *
+ * Example of `options.fileChooser` performing the work done in express-enrouten's
+ * `createFileHandler()` function:
+ *
+ * var options = {
+ *   excludeDotFiles: true,
+ *   fileChooser: function (filename) {
+ *     var impl;
+ *     if (isFileModule(filename)) {
+ *       impl = require(filename);
+ *       if (impl instanceof Function && impl.length === 1) {
+ *         return true;
+ *       }
+ *     }
+ *     return false;
+ *   }
+ * };
+ *
+ * var routes = routeify('./controllers', options);
+ *
+ */
+
+/**
+ * Maps handlers in directories to routes based on the filename
+ * and path to the file.
+ *
+ * @param basedir {String} Base directory to search for files.
+ * @param options {Object} Options used during traversal.
+ * @param options.fileChooser {Function} Function taking one argument (current filename) and returning
+ *                                       a {boolean} value indicating whether the current file should
+ *                                       be mapped to a route.
+ * @returns Returns a hash of local filenames to routes appropriate for mounting.
+ */
+module.exports = function mapDirectory(basedir, options) {
+  var routes = {}; // accumulated recursion
+
+  options || (options = {});
+  options.fileChooser = options.fileChooser && (typeof options.fileChooser === 'function') ? options.fileChooser : null;
+
+  traverse(basedir, '', '', routes, options)
+
+  return routes;
+}
+
+/**
+ * Visits `current` w.r.t. `ancestors`, adding a route to the `routes`
+ * hash if a filename, or recursively visiting the children of `current`
+ * if it is a directory.
+ */
+function traverse(basedir, ancestors, current, routes, options) {
+  var abs, stat;
+
+  abs = path.join(basedir, ancestors, current);
+  stat = fs.statSync(abs);
+
+  // no dotted directories
+  if (stat.isDirectory() && current.charAt(0) !== '.') {
+    ancestors = ancestors ? path.join(ancestors, current) : current;
+
+    var items = fs.readdirSync(abs);
+
+    // sort items alphabetically and with 'index.js' first
+    items.sort(directorySorter);
+
+    items.forEach(function (child) {
+      traverse(basedir, ancestors, child, routes, options);
+    });
+  }
+
+  if (stat.isFile()) {
+    var mountpath, filename, route;
+
+    if (!options.fileChooser || options.fileChooser(abs)) {
+      mountpath = ancestors ? ancestors.split(path.sep) : [];
+
+      filename = path.basename(current, path.extname(current));
+      if (filename !== 'index') {
+        mountpath.push(filename);
+      }
+
+      route = createRouteFromPath(mountpath);
+      routes[route] = abs;
+    }
+  }
+}
+
+/**
+ * Converts `/a/b/{c}/d/{e}` to `/a/b/:c/d/:e`
+ */
+function createRouteFromPath(pathname) {
+  var reRouteSpec = /\{([^\}]+)\}/g;
+  return ('/' + pathname.join('/')).replace(reRouteSpec, ':$1');
+}
+
+/**
+ * Sorts `index.js` before all other items.
+ */
+function directorySorter(a, b) {
+  if (a === b) {
+    return 0;
+  }
+  else if (a === 'index.js') {
+    return -2;
+  }
+  else if (b === 'index.js') {
+    return 2;
+  }
+  else {
+    return (a < b) ? -1 : 1;
+  }
+}


### PR DESCRIPTION
This PR changes the default behavior of express-enrouten to process files in directory mode alphabetically (explicitly) and to process `index.js` before all other files. This allows _slightly_ more predictable route handling as structures get more complex. With this change, routes which _must_ go earlier can be put into `index.js` for the given level.

Old behavior:

```
[development] Listening on http://localhost:8000
[router] GET      /about/                                  (./controllers/about.js)
[router] POST     /amz-ses/                                (./controllers/amz-ses.js)
[router] GET      /ecgs/:ecg                               (./controllers/ecgs/index.js)
[router] POST     /ecgs/:ecg                               (./controllers/ecgs/index.js)
[router] POST     /ecgs/:ecg/tags                          (./controllers/ecgs/index.js)
[router] POST     /ecgs/:ecg/signature                     (./controllers/ecgs/index.js)
[router] POST     /ecgs/:ecg/uploaded                      (./controllers/ecgs/index.js)
[router] GET      /                                        (./controllers/index.js)
[router] GET      /success                                 (./controllers/index.js)
[router] GET      /login/                                  (./controllers/login/index.js)
[router] POST     /login/                                  (./controllers/login/index.js)
[router] GET      /login/reset/                            (./controllers/login/reset.js)
[router] POST     /login/reset/                            (./controllers/login/reset.js)
[router] GET      /login/reset/sent                        (./controllers/login/reset.js)
...
```

New behavior:

```
[development] Listening on http://localhost:8000
[router] GET      /                                        (./controllers/index.js)
[router] GET      /success                                 (./controllers/index.js)
[router] GET      /about/                                  (./controllers/about.js)
[router] POST     /amz-ses/                                (./controllers/amz-ses.js)
[router] GET      /ecgs/:ecg                               (./controllers/ecgs/index.js)
[router] POST     /ecgs/:ecg                               (./controllers/ecgs/index.js)
[router] POST     /ecgs/:ecg/tags                          (./controllers/ecgs/index.js)
[router] POST     /ecgs/:ecg/signature                     (./controllers/ecgs/index.js)
[router] POST     /ecgs/:ecg/uploaded                      (./controllers/ecgs/index.js)
[router] GET      /login/                                  (./controllers/login/index.js)
[router] POST     /login/                                  (./controllers/login/index.js)
[router] GET      /login/reset/                            (./controllers/login/reset.js)
[router] POST     /login/reset/                            (./controllers/login/reset.js)
[router] GET      /login/reset/sent                        (./controllers/login/reset.js)
...
```

This may be a breaking change for some consumers if they rely on the current behavior for proper route selection (perhaps on case-insensitive file systems).
