### PR TITLE
String handlers

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var assert = require('assert');
+var path = require('path');
 
 /**
  * The `routes` configuration option handler.
@@ -11,7 +12,7 @@ module.exports = function routes(router, options) {
             var method, middleware;
 
             if (typeof def.handler === 'string') {
-                def.handler = require(def.handler);
+                def.handler = require(path.resolve(def.handler));
             }
 
             assert(def.path, 'path is required');

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -10,6 +10,10 @@ module.exports = function routes(router, options) {
         options.forEach(function (def) {
             var method, middleware;
 
+            if (typeof def.handler === 'string') {
+                def.handler = require(def.handler);
+            }
+
             assert(def.path, 'path is required');
             assert(typeof def.handler === 'function', 'handler is required');
 


### PR DESCRIPTION
When using the `routes` option... Is there a reason enrouten doesn't allow you to pass your handlers as path names, which it would then resolve and load for you - when they are needed - as is done in this PR?

I'm currently working on an app in which route handlers are configured via Confit:

```
"routes": [
	{ "path": "/test", "method": "GET", "handler": "require:./handler" }
]
```

Using this approach, the `handler` that is referenced here will be loaded by Confit as it initializes the configuration object... but that's causing a race condition wherein the `handler` module expects a separate module to be initialized (but it hasn't - yet).

This PR allows me to do this instead:

```
"routes": [
	{ "path": "/test", "method": "GET", "handler": "path:./handler" }
]
```

As a result, `handler` is not require()'d until it's actually needed... and not during Confit's initialization process.