### PR TITLE
remove reverend in favor of path-to-regexp

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,12 +20,12 @@
 var path = require('path');
 var caller = require('caller');
 var express = require('express');
-var reverend = require('reverend');
 var debug = require('debuglog')('enrouten');
 var index = require('./lib/index');
 var routes = require('./lib/routes');
 var registry = require('./lib/registry');
 var directory = require('./lib/directory');
+var path2regexp = require('path-to-regexp');
 
 
 /**
@@ -73,7 +73,7 @@ function mount(app, options) {
                 var route;
                 route = this.routes[name];
                 if (typeof route === 'string') {
-                    return reverend(route, data || {});
+                    return path2regexp.compile(route)(data);
                 }
                 return undefined;
             }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   "dependencies": {
     "caller": "^1.0.0",
     "debuglog": "^1.0.1",
-    "reverend": "^0.3.0"
+    "path-to-regexp": "^1.1.1"
   }
 }


### PR DESCRIPTION
[Path-to-regexp], which powers [Reverend], has recently added the [ability to reverse routes](https://github.com/pillarjs/path-to-regexp#compile-reverse-path-to-regexp), rendering `Reverend` unecessary.

The sole differences between the implementation in `Reverend` and that of `path-to-regexp` is a bit of duck-typing to prevent throws. This small amount of duck-typing can be seen in the [shim](http://github.com/krakenjs/reverend/blob/shim/index.js) branch.

[path-to-regexp]: https://github.com/pillarjs/path-to-regexp
[reverend]: https://github.com/krakenjs/reverend