### PR TITLE
Ignore invalid files with no extension

### DIFF
--- a/lib/directory.js
+++ b/lib/directory.js
@@ -86,6 +86,7 @@ function createFileHandler(router, options) {
  * @returns {boolean}
  */
 function isFileModule(file) {
+    debug('Verifying that ', file, ' is a loadable module');
     var ext = path.extname(file);
 
     // Omit dotfiles
@@ -96,12 +97,14 @@ function isFileModule(file) {
     }
 
     try {
-        // remove the file extension and use require.resolve to resolve known
+        // remove the file extension and use require to resolve known
         // file types eg. CoffeeScript. Will throw if not found/loadable by node.
-        file = ext ? file.slice(0, -ext.length) : file;
-        require.resolve(file);
+        file = file.slice(0, file.length -ext.length);
+        require(file);
+
         return true;
     } catch (err) {
+        debug('Unable to load ', file, err);
         return false;
     }
 }

--- a/test/enrouten.js
+++ b/test/enrouten.js
@@ -176,6 +176,20 @@ function run(test, name, mount, fn) {
             });
         });
 
+        t.test('no extension', function (t) {
+            var app, settings;
+
+            app = express();
+            settings = {
+                directory: path.join('fixtures', 'noExtension')
+            };
+
+            fn(app, settings);
+            get(app, mount + '/controller', function (err) {
+                t.error(err);
+                t.end();
+            });
+        });
 
         t.test('index', function (t) {
             var app, settings;

--- a/test/fixtures/noExtension/controller
+++ b/test/fixtures/noExtension/controller
@@ -1,0 +1,14 @@
+/**
+ * This is a valid js file with no extension.
+ * This file _can_ be require()'d by node.
+ * See: https://nodejs.org/api/modules.html#modules_all_together
+ */
+'use strict';
+
+module.exports = function (router) {
+
+    router.get('/', function (req, res) {
+        res.send('ok');
+    });
+
+};

--- a/test/fixtures/superfluous/noExtensionFile
+++ b/test/fixtures/superfluous/noExtensionFile
@@ -1,0 +1,1 @@
+Klaatu barada nikto


### PR DESCRIPTION
Proposed fix for https://github.com/krakenjs/express-enrouten/issues/73

Instead of just trying to resolve a module during the `isFileModule` verification step, try to load it.

Since this block is already surrounded by a try/catch statement it's a safe
place to attempt requiring a module. I don't think it's wasted effort, since
the whole point of validating the modules is to try to load them later.

Also, some very minor refactoring of the extension removal code to make it more readable.
