### PR TITLE
Add ignore support

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,12 +20,12 @@
 var path = require('path');
 var caller = require('caller');
 var express = require('express');
-var debug = require('debuglog')('enrouten');
 var index = require('./lib/index');
 var routes = require('./lib/routes');
 var registry = require('./lib/registry');
 var directory = require('./lib/directory');
 var path2regexp = require('path-to-regexp');
+var debug = require('debuglog')('enrouten');
 
 
 /**
@@ -55,8 +55,24 @@ function mount(app, options) {
             index(router, options.index);
         }
 
-        if (typeof options.directory === 'string') {
-            options.directory = resolve(options.basedir, options.directory);
+        if ((options.directory && typeof options.directory === 'object' && typeof options.directory.path === 'string')
+            // Deprecated: Keep this one for backwards compatibility.
+            || typeof options.directory === 'string') {
+
+            // Cast legacy config into new config.
+            if (typeof options.directory === 'string') {
+                console.error('express-enrouten:\n' +
+                    'Deprecated configuration. Directory config must be an object:\n ' +
+                    '{"path":"path/to/controllers" [, ignore:["pattern1, ... patternN"]}');
+                options.directory = {
+                    path: options.directory,
+                    ignore: []
+                }
+            }
+
+            options.directory.path = resolve(options.basedir, options.directory.path);
+            options.directory.ignore = options.directory.ignore || [];
+
             directory(router, options.directory, routerOptions);
         }
 

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -2,14 +2,15 @@
 
 var fs = require('fs');
 var path = require('path');
+var minimatch = require('minimatch');
 var registry = require('./registry');
 var debug = require('debuglog')('enrouten/directory');
 
 
-module.exports = function directory(router, basedir, options) {
+module.exports = function directory(router, config, routerOptions) {
     var handler;
-    handler = createFileHandler(router, options);
-    traverse(basedir, '', '', handler);
+    handler = createFileHandler(router, routerOptions);
+    traverse(config.path, '', '', config.ignore, handler);
     return router;
 };
 
@@ -18,20 +19,33 @@ module.exports = function directory(router, basedir, options) {
  * Traverses the provided basedir, invoking the provided function when a file
  * is encountered.
  * @param basedir the root directory where the traversal should begin
- * @param ancesors the relative path from the basedir to the current dir
+ * @param ancestors the relative path from the basedir to the current dir
  * @param current the current directory name
+ * @param ignore an array of file patterns to ignore (uses glob-style patterns, eg: ['controllers/**', '/notMe.js'])
  * @param fn the function to invoke when a file is encountered: `function (basedir, ancestors, current)`
  */
-function traverse(basedir, ancestors, current, fn) {
+function traverse(basedir, ancestors, current, ignore, fn) {
     var abs, stat;
 
     abs = path.join(basedir, ancestors, current);
+
+    //If this file matches any of the patterns in the "ignore" configuration, skip it.
+    var ignorable = ignore.some(function (pattern) {
+        //Make the file path pseudo-absolute, so that the ignore patterns can be properly applied.
+        var file = path.join('/', ancestors, current);
+        return minimatch(file, pattern, {matchBase: true})
+    });
+
+    if (ignorable) {
+        return;
+    }
+
     stat = fs.statSync(abs);
 
     if (stat.isDirectory()) {
         ancestors = ancestors ? path.join(ancestors, current) : current;
         fs.readdirSync(abs).forEach(function (child) {
-            traverse(basedir, ancestors, child, fn);
+            traverse(basedir, ancestors, child, ignore, fn);
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
     "istanbul": "^0.3.2",
     "jshint": "^2.5.10",
     "supertest": "^0.15.0",
-    "tape": "^3.0.3"
+    "tape": "^4.4.0"
   },
   "dependencies": {
     "caller": "^1.0.0",
     "debuglog": "^1.0.1",
+    "minimatch": "^3.0.0",
     "path-to-regexp": "^1.1.1"
   }
 }

--- a/test/enrouten.js
+++ b/test/enrouten.js
@@ -43,11 +43,11 @@ function run(test, name, mount, fn) {
         app = express();
         fn(app);
 
-        fn(app, { basedir: path.join(__dirname, 'fixtures') });
-        fn(app, { directory: null });
-        fn(app, { index: null });
-        fn(app, { routes: null });
-        fn(app, { routes: [] });
+        fn(app, {basedir: path.join(__dirname, 'fixtures')});
+        fn(app, {directory: null});
+        fn(app, {index: null});
+        fn(app, {routes: null});
+        fn(app, {routes: []});
 
         // Enrouten always adds one router, regardless
         // of config.
@@ -233,6 +233,30 @@ function run(test, name, mount, fn) {
                     t.end();
                 });
             });
+        });
+
+
+        t.test('ignore configuration', function (t) {
+
+            var app, settings;
+
+            app = express();
+            settings = {
+                directory: path.join('fixtures', 'ignore')
+            };
+
+            t.plan(1);
+            t.doesNotThrow(function () {
+                fn(app, settings);
+                t.plan(3);
+                get(app, mount + '/controller', function (err) {
+                    t.error(err);
+                    get(app, mount + '/subignore/subcontroller', function (err) {
+                        t.error(err);
+                        // Expected to fail, as we want to ignore this file.
+                    });
+                });
+            }, 'Invalid files are ignored and do not cause failures');
         });
 
 
@@ -510,7 +534,7 @@ function run(test, name, mount, fn) {
             t.end();
         });
 
-        t.test('single middleware', function(t) {
+        t.test('single middleware', function (t) {
             var app, settings;
 
             app = express();
@@ -520,7 +544,7 @@ function run(test, name, mount, fn) {
                         path: '/',
                         method: 'get',
                         middleware: [
-                            function(req, res, next) {
+                            function (req, res, next) {
                                 res.value = 'middleware';
                                 next();
                             }
@@ -543,7 +567,7 @@ function run(test, name, mount, fn) {
                 });
         });
 
-        t.test('multiple middleware', function(t) {
+        t.test('multiple middleware', function (t) {
             var app, settings;
 
             app = express();
@@ -553,11 +577,11 @@ function run(test, name, mount, fn) {
                         path: '/',
                         method: 'get',
                         middleware: [
-                            function(req, res, next) {
+                            function (req, res, next) {
                                 res.value1 = 1;
                                 next();
                             },
-                            function(req, res, next) {
+                            function (req, res, next) {
                                 res.value2 = 2;
                                 next();
                             }
@@ -580,7 +604,7 @@ function run(test, name, mount, fn) {
                 });
         });
 
-        t.test('error thrown in middleware', function(t) {
+        t.test('error thrown in middleware', function (t) {
             var app, settings;
 
             app = express();
@@ -590,10 +614,10 @@ function run(test, name, mount, fn) {
                         path: '/',
                         method: 'get',
                         middleware: [
-                            function(req, res, next) {
+                            function (req, res, next) {
                                 next(new Error('middleware error'));
                             },
-                            function(req, res, next) {
+                            function (req, res, next) {
                                 res.msg = 'You wont see this';
                                 next();
                             }
@@ -608,7 +632,7 @@ function run(test, name, mount, fn) {
             fn(app, settings);
 
             // error handler
-            app.use(function(err, req, res, next) {
+            app.use(function (err, req, res, next) {
                 res.status(503).send(err.message);
             });
 
@@ -635,12 +659,12 @@ function run(test, name, mount, fn) {
             };
 
             // enrouten not yet run
-            actual = enrouten.path(app, 'the-bar', { id: 10 });
+            actual = enrouten.path(app, 'the-bar', {id: 10});
             t.equal(actual, undefined);
 
             fn(app, settings);
 
-            actual = enrouten.path(app, 'the-bar', { id: 10 });
+            actual = enrouten.path(app, 'the-bar', {id: 10});
             t.equal(actual, mount + '/bar/10');
 
             actual = enrouten.path(app, 'my-bar');
@@ -663,7 +687,7 @@ function run(test, name, mount, fn) {
 
             fn(app, settings);
 
-            actual = app.locals.enrouten.path('the-bar', { id: 10 });
+            actual = app.locals.enrouten.path('the-bar', {id: 10});
             t.equal(actual, mount + '/bar/10');
 
             actual = app.locals.enrouten.path('my-bar');

--- a/test/enrouten.js
+++ b/test/enrouten.js
@@ -242,7 +242,14 @@ function run(test, name, mount, fn) {
 
             app = express();
             settings = {
-                directory: path.join('fixtures', 'ignore')
+                directory: {
+                    path: path.join('fixtures', 'ignore'),
+                    ignore: [
+                        'noExtensionFile', // It will ignore any file named "noExtensionFile"
+                        '**/_CVS/*',  // It will ignore the contents of any "_CSV" directory
+                        '/subignore/notAController.js' // It will ignore this specific file, relative to the path above.
+                    ]
+                }
             };
 
             t.plan(1);
@@ -253,7 +260,6 @@ function run(test, name, mount, fn) {
                     t.error(err);
                     get(app, mount + '/subignore/subcontroller', function (err) {
                         t.error(err);
-                        // Expected to fail, as we want to ignore this file.
                     });
                 });
             }, 'Invalid files are ignored and do not cause failures');

--- a/test/enrouten.js
+++ b/test/enrouten.js
@@ -63,7 +63,9 @@ function run(test, name, mount, fn) {
 
             app = express();
             settings = {
-                directory: path.join('fixtures', 'flat')
+                directory: {
+                    path: path.join('fixtures', 'flat')
+                }
             };
 
             fn(app, settings);
@@ -79,7 +81,9 @@ function run(test, name, mount, fn) {
 
             app = express();
             settings = {
-                directory: path.join(__dirname, 'fixtures', 'flat')
+                directory: {
+                    path: path.join(__dirname, 'fixtures', 'flat')
+                }
             };
 
             fn(app, settings);
@@ -95,7 +99,9 @@ function run(test, name, mount, fn) {
 
             app = express();
             settings = {
-                directory: path.join('fixtures', 'nested')
+                directory: {
+                    path: path.join('fixtures', 'nested')
+                }
             };
 
             fn(app, settings);
@@ -116,7 +122,9 @@ function run(test, name, mount, fn) {
             app = express();
             app.set('case sensitive routing', true);
             settings = {
-                directory: path.join('fixtures', 'caseSensitive'),
+                directory: {
+                    path: path.join('fixtures', 'caseSensitive')
+                },
                 routerOptions: {
                     caseSensitive: true
                 }
@@ -182,7 +190,9 @@ function run(test, name, mount, fn) {
 
             app = express();
             settings = {
-                directory: path.join('fixtures', 'indexed')
+                directory: {
+                    path: path.join('fixtures', 'indexed')
+                }
             };
 
             fn(app, settings);
@@ -205,7 +215,9 @@ function run(test, name, mount, fn) {
 
             app = express();
             settings = {
-                directory: path.join('fixtures', 'undefined')
+                directory: {
+                    path: path.join('fixtures', 'undefined')
+                }
             };
 
             t.throws(function () {
@@ -221,7 +233,9 @@ function run(test, name, mount, fn) {
 
             app = express();
             settings = {
-                directory: path.join('fixtures', 'superfluous')
+                directory: {
+                    path: path.join('fixtures', 'superfluous')
+                }
             };
 
             fn(app, settings);
@@ -271,7 +285,9 @@ function run(test, name, mount, fn) {
 
             app = express();
             settings = {
-                directory: path.join('fixtures', 'named', 'routes')
+                directory: {
+                    path: path.join('fixtures', 'named', 'routes')
+                }
             };
 
             fn(app, settings);
@@ -299,7 +315,9 @@ function run(test, name, mount, fn) {
 
             app = express();
             settings = {
-                directory: path.join('fixtures', 'named', 'duplicates')
+                directory: {
+                    path: path.join('fixtures', 'named', 'duplicates')
+                }
             };
 
             t.throws(function () {
@@ -661,7 +679,9 @@ function run(test, name, mount, fn) {
 
             app = express();
             settings = {
-                directory: path.join('fixtures', 'named', 'routes')
+                directory: {
+                    path: path.join('fixtures', 'named', 'routes')
+                }
             };
 
             // enrouten not yet run
@@ -688,7 +708,9 @@ function run(test, name, mount, fn) {
 
             app = express();
             settings = {
-                directory: path.join('fixtures', 'named', 'routes')
+                directory: {
+                    path: path.join('fixtures', 'named', 'routes')
+                }
             };
 
             fn(app, settings);

--- a/test/fixtures/ignore/_CVS/Entries
+++ b/test/fixtures/ignore/_CVS/Entries
@@ -1,0 +1,1 @@
+I am an entry

--- a/test/fixtures/ignore/controller.js
+++ b/test/fixtures/ignore/controller.js
@@ -1,0 +1,10 @@
+'use strict';
+
+
+module.exports = function (router) {
+
+    router.get('/', function (req, res) {
+        res.send('ok');
+    });
+
+};

--- a/test/fixtures/ignore/noExtensionFile
+++ b/test/fixtures/ignore/noExtensionFile
@@ -1,0 +1,1 @@
+Klaatu barada nikto

--- a/test/fixtures/ignore/subignore/noExtensionFile
+++ b/test/fixtures/ignore/subignore/noExtensionFile
@@ -1,0 +1,1 @@
+Klaatu barada nikto

--- a/test/fixtures/ignore/subignore/notAController.js
+++ b/test/fixtures/ignore/subignore/notAController.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = function (notTheRouterYouAreLookingFor) {
+
+    throw new Error('I should not load');
+
+};

--- a/test/fixtures/ignore/subignore/subcontroller.js
+++ b/test/fixtures/ignore/subignore/subcontroller.js
@@ -1,0 +1,10 @@
+'use strict';
+
+
+module.exports = function (router) {
+
+    router.get('/', function (req, res) {
+        res.send('ok');
+    });
+
+};

--- a/test/fixtures/superfluous/noExtensionFile
+++ b/test/fixtures/superfluous/noExtensionFile
@@ -1,1 +1,0 @@
-Klaatu barada nikto

--- a/test/fixtures/superfluous/noExtensionFile
+++ b/test/fixtures/superfluous/noExtensionFile
@@ -1,0 +1,1 @@
+Klaatu barada nikto


### PR DESCRIPTION
Adds a configurable list of files to ignore.
Uses [minimatch](https://github.com/isaacs/minimatch) to provide shell glob patterns, similar to .*ignore files.

Basically, instead of simply specifying the path to the directory, you can now optionally provide an array like:

``` javascript
{
    directory: {
        path: 'path/to/controllers',
        ignore: [
            'noExtensionFile',              // It will ignore any file named "noExtensionFile".
            '**/_CVS/*',                    // It will ignore the contents of any "_CSV" directory.
            '/subignore/notAController.js'  // It will ignore this specific file, relative to the path above.
        ]
    }
}
```

Another proposal to fix #73 

If this looks OK, I'll write in the documentation updates before it's merged.
