### PR TITLE
Bug: Fix bad duplicate name resolution

### DIFF
--- a/lib/directory.js
+++ b/lib/directory.js
@@ -94,14 +94,26 @@ function isFileModule(file) {
     if (path.basename(file, ext)[0] === '.') {
         return false;
     }
+    
+    if (ext !== '' && !isValidExtension(ext)) {
+      return false;
+    }
 
     try {
-        // remove the file extension and use require.resolve to resolve known
-        // file types eg. CoffeeScript. Will throw if not found/loadable by node.
-        file = ext ? file.slice(0, -ext.length) : file;
-        require.resolve(file);
+        require(file);
         return true;
     } catch (err) {
         return false;
     }
+}
+
+/**
+ * Returns true if `ext` is an extension with a registered handler
+ * in module.extensions.
+ * @param ext the file extension to check
+ * @returns {boolean}
+ */
+function isValidExtension(ext) {
+  var keys = Object.keys(require.extensions);
+  return keys.indexOf(ext) !== -1; 
 }

--- a/test/enrouten.js
+++ b/test/enrouten.js
@@ -90,6 +90,42 @@ function run(test, name, mount, fn) {
         });
 
 
+        t.test('unknown extensions (regression)', function (t) {
+            var app, settings;
+
+            app = express();
+            settings = {
+                directory: path.join(__dirname, 'fixtures', 'extensions', 'unknown')
+            };
+
+            fn(app, settings);
+            get(app, mount + '/controller', function (err) {
+                t.error(err);
+                t.end();
+            });
+        });
+
+
+        t.test('custom extensions', function (t) {
+            var app, settings;
+
+            require.extensions['.custom'] = require.extensions['.js'];
+            
+            app = express();
+            settings = {
+                directory: path.join(__dirname, 'fixtures', 'extensions', 'custom')
+            };
+
+            fn(app, settings);
+            
+            get(app, mount + '/controller', function (err) {
+                t.error(err);
+                delete require.extensions['.custom'];
+                t.end();
+            });              
+        });
+
+
         t.test('nested', function (t) {
             var app, settings;
 

--- a/test/fixtures/extensions/custom/controller.custom
+++ b/test/fixtures/extensions/custom/controller.custom
@@ -1,0 +1,10 @@
+'use strict';
+
+
+module.exports = function (router) {
+
+    router.get('/', function (req, res) {
+        res.send('ok');
+    });
+
+};

--- a/test/fixtures/extensions/unknown/controller.custom
+++ b/test/fixtures/extensions/unknown/controller.custom
@@ -1,0 +1,1 @@
+throw new Error('you\'re out!');

--- a/test/fixtures/extensions/unknown/controller.js
+++ b/test/fixtures/extensions/unknown/controller.js
@@ -1,0 +1,10 @@
+'use strict';
+
+
+module.exports = function (router) {
+
+    router.get('/', function (req, res) {
+        res.send('ok');
+    });
+
+};


### PR DESCRIPTION
We were using `require.resolve` to ensure we used the built-in resolution mechanism however this is insufficient.

`require.resolve` will resolve if given a path with extension but, without one, it attepts to resolve with the registered extensions. That's why we did it. Problem is, if you have two files with the same name but different extensions, both will pass the resolution test if at least one of them uses a registered extension.

This change supports the existing resolution process in node (treat extension-less files as *.js, check files with extensions against the registered handlers). It will also prevent errors from spawning when a file fails to load (though it will still fail loudly if the loaded file doesn't have a signature of `function (thing) {}`.

Closes #77
