### PR TITLE
add babel 6 default export support

### DIFF
--- a/lib/directory.js
+++ b/lib/directory.js
@@ -53,13 +53,10 @@ function traverse(basedir, ancestors, current, fn) {
 function createFileHandler(router, options) {
 
     return function handler(basedir, ancestors, current) {
-        var abs, impl, filename, mountpath, subrouter;
+        var abs, impl, filename;
 
-        abs = path.join(basedir, ancestors, current);
-        filename = path.basename(current, path.extname(current));
-
-        if (isFileModule(abs)) {
-            impl = require(abs);
+        function mount(impl, filename) {
+            var mountpath, subrouter;
 
             if (typeof impl === 'function' && impl.length === 1) {
                 // Build current pount path, ignoring `index` in lieu of `/`
@@ -71,6 +68,19 @@ function createFileHandler(router, options) {
                 subrouter = registry(mountpath, router, options);
                 impl(subrouter);
                 router.use(mountpath, subrouter._router);
+                return true;
+            }
+        }
+
+        abs = path.join(basedir, ancestors, current);
+        filename = path.basename(current, path.extname(current));
+
+        if (isFileModule(abs)) {
+            impl = require(abs);
+            if (!mount(impl, filename)) {
+              if (impl && impl.default) {
+                mount(impl.default, filename);
+              }
             }
         }
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,11 @@ module.exports = function index(router, file) {
     var module;
 
     module = require(file);
+
+    if (typeof module === 'object' && module.default) {
+        module = module.default;
+    }
+
     assert.equal(typeof module, 'function', 'An index file must export a function.');
     assert.equal(module.length, 1, 'An index file must export a function that accepts a single argument.');
 

--- a/test/enrouten.js
+++ b/test/enrouten.js
@@ -142,6 +142,23 @@ function run(test, name, mount, fn) {
 
             t.end();
         });
+
+
+        t.test('es6 default export', function (t) {
+            var app, settings;
+
+            app = express();
+            settings = {
+                directory: path.join('fixtures', 'transpiled')
+            };
+
+            fn(app, settings);
+
+            get(app, mount + '/controller', function (err) {
+                t.error(err);
+                t.end();
+            });
+        });
         
         
         t.test('nested', function (t) {
@@ -375,6 +392,23 @@ function run(test, name, mount, fn) {
                     t.error(err);
                     t.end();
                 });
+            });
+        });
+
+
+        t.test('transpiled from es6', function (t) {
+            var app, settings;
+
+            app = express();
+            settings = {
+                index: path.join('fixtures', 'transpiled', 'controller')
+            };
+
+            fn(app, settings);
+
+            get(app, mount, function (err) {
+                t.error(err);
+                t.end();
             });
         });
 

--- a/test/fixtures/transpiled/controller.js
+++ b/test/fixtures/transpiled/controller.js
@@ -1,0 +1,11 @@
+'use strict';
+
+
+// faking a module transpiled from es6
+exports.default = function (router) {
+
+    router.get('/', function (req, res) {
+        res.send('ok');
+    });
+
+};


### PR DESCRIPTION
This allows folks to use es6 transpiled by babel 6 for the controllers

/cc @totherik
