### PR TITLE
give some kind of error when require fails

### DIFF
--- a/lib/directory.js
+++ b/lib/directory.js
@@ -82,6 +82,8 @@ function createFileHandler(router, options) {
                 mount(impl.default, filename);
               }
             }
+        } else {
+            debug('failed to mount - file wasn\'t requireable', abs);
         }
     };
 


### PR DESCRIPTION
In the event that a user is executing code before a module is exported there may be an error.
The try statement in `isFileModule` silences any errors that might occur at require time. 
This creates an annoying debugging issue where a route just won't be mounted and there won't be any explanation.

Also, there is no documentation about debugging and enabling the log messages.

E.X

Will fail since `someBadMethod` is undefined. It won't mount and it will remain silent.

``` js
someBadMethod();

module.exports = function (app) {
  // .. etc
}
```

If you move the failed method inside of the function you
can capture the failure.

``` js
module.exports = function (app) {
  someBadMethod();
  // .. etc
}
```
