### PR TITLE
Allow other require extensions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,9 @@ function scanRequireExtensions(baseFilename) {
             return path; // short circuit loop
         }
     }
+
+    // nothing found so just return original name
+    return baseFilename;
 }
 
 /**
@@ -34,7 +37,7 @@ function scanRequireExtensions(baseFilename) {
  */
 module.exports = function index(router, file) {
     var module;
-    var fileName = scanRequireExtensions(file)
+    var fileName = scanRequireExtensions(file);
 
     module = require(fileName);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,29 @@
 
 var assert = require('assert');
 var debug = require('debuglog')('enrouten/index');
+var fs = require('fs');
+
+// scan for all require extensions so stuff like .coffee and .ts will work
+function scanRequireExtensions(baseFilename) {
+    // .js is the most common case so check that first
+    var path = baseFilename + '.js';
+
+    if (fs.existsSync(path)) {
+        return path;
+    }
+
+    for (var extension in require.extensions) {
+        if (extension === '.js' || extension === '.json') {
+            // We already checked .js above and .json will not work
+            // since we need a function exported
+            continue;
+        }
+        path = baseFilename + extension;
+        if (fs.existsSync(path)) {
+            return path; // short circuit loop
+        }
+    }
+}
 
 /**
  * The `index` configuration option handler
@@ -11,8 +34,9 @@ var debug = require('debuglog')('enrouten/index');
  */
 module.exports = function index(router, file) {
     var module;
+    var fileName = scanRequireExtensions(file)
 
-    module = require(file);
+    module = require(fileName);
 
     if (typeof module === 'object' && module.default) {
         module = module.default;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     }
   ],
   "devDependencies": {
+    "coffee-script": "^1.9.3",
     "express": "^4.10.3",
     "istanbul": "^0.3.2",
     "jshint": "^2.5.10",

--- a/test/enrouten.js
+++ b/test/enrouten.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('coffee-script/register');
 var test = require('tape');
 var path = require('path');
 var express = require('express');
@@ -110,19 +111,37 @@ function run(test, name, mount, fn) {
             var app, settings;
 
             require.extensions['.custom'] = require.extensions['.js'];
-            
+
             app = express();
             settings = {
                 directory: path.join(__dirname, 'fixtures', 'extensions', 'custom')
             };
 
             fn(app, settings);
-            
+
             get(app, mount + '/controller', function (err) {
                 t.error(err);
                 delete require.extensions['.custom'];
                 t.end();
-            });              
+            });
+        });
+
+        t.test('compile to js extensions', function (t) {
+            var app, settings;
+
+            app = express();
+            settings = {
+                index: path.join(__dirname, 'fixtures', 'compiled', "routes")
+            };
+
+            fn(app, settings);
+            get(app, mount, function (err) {
+                t.error(err);
+                get(app, mount + '/coffee', function (err) {
+                    t.error(err);
+                    t.end();
+                });
+            });
         });
 
 
@@ -159,8 +178,8 @@ function run(test, name, mount, fn) {
                 t.end();
             });
         });
-        
-        
+
+
         t.test('nested', function (t) {
             var app, settings;
 

--- a/test/fixtures/compiled/routes.coffee
+++ b/test/fixtures/compiled/routes.coffee
@@ -1,0 +1,7 @@
+module.exports = (router) ->
+
+    router.get '/', (req, res) ->
+        res.send('ok')
+
+    router.get '/coffee', (req, res) ->
+        res.send('ok')

--- a/test/fixtures/compiled/routes.json
+++ b/test/fixtures/compiled/routes.json
@@ -1,0 +1,3 @@
+{
+    "This": "does not fulfill the controller API, so should be silently ignored."
+}


### PR DESCRIPTION
I have a `routes.coffee` and `routes.json` file I'm using in my project and it is breaking. However using `routes.js` instead of coffee works.

What happens is that when it tries to require the coffee file, it loads the json file first, which cannot export a function so the assertion fails. I created a fix here which first looks at `.js` and then tries all other require extensions other than `json`.
