### PR TITLE
Added extensions configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ app.use(enrouten({
 }));
 ```
 
+#### extentions
+The `extensions` configuration option (optional) is a workaround for failures in test frameworks like Jest because
+they disallow the use of require.extensions (which is deprecated).
+
+  ```javascript
+app.use(enrouten({
+    directory: 'controllers',
+    extensions: {
+      '.js': 1,
+      '.json': 1,
+      '.node': 1
+    }
+}));
+```
 
 ### Named Routes
 For `index` and `directory` configurations there is also support for named routes.

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function mount(app, options) {
 
         if (typeof options.directory === 'string') {
             options.directory = resolve(options.basedir, options.directory);
-            directory(router, options.directory, routerOptions);
+            directory(router, options.directory, routerOptions, options.extensions);
         }
 
         if (typeof options.routes === 'object') {

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -6,9 +6,9 @@ var registry = require('./registry');
 var debug = require('debuglog')('enrouten/directory');
 
 
-module.exports = function directory(router, basedir, options) {
+module.exports = function directory(router, basedir, options, extensions) {
     var handler;
-    handler = createFileHandler(router, options);
+    handler = createFileHandler(router, options, extensions);
     traverse(basedir, '', '', handler);
     return router;
 };
@@ -50,7 +50,7 @@ function traverse(basedir, ancestors, current, fn) {
  * @param options the options object to pass to each express Router created
  * @returns {Function} the implementation function to provide to direc`tory
  */
-function createFileHandler(router, options) {
+function createFileHandler(router, options, extensions) {
 
     return function handler(basedir, ancestors, current) {
         var abs, impl, filename;
@@ -75,7 +75,7 @@ function createFileHandler(router, options) {
         abs = path.join(basedir, ancestors, current);
         filename = path.basename(current, path.extname(current));
 
-        if (isFileModule(abs)) {
+        if (isFileModule(abs, extensions)) {
             impl = require(abs);
             if (!mount(impl, filename)) {
               if (impl && impl.default) {
@@ -95,7 +95,7 @@ function createFileHandler(router, options) {
  * @param file the file for which to determine module-ness.
  * @returns {boolean}
  */
-function isFileModule(file) {
+function isFileModule(file, extensions) {
     var ext = path.extname(file);
 
     // Omit dotfiles
@@ -105,7 +105,7 @@ function isFileModule(file) {
         return false;
     }
     
-    if (ext !== '' && !isValidExtension(ext)) {
+    if (ext !== '' && !isValidExtension(ext, extensions)) {
       return false;
     }
 
@@ -118,7 +118,7 @@ function isFileModule(file) {
  * @param ext the file extension to check
  * @returns {boolean}
  */
-function isValidExtension(ext) {
-  var keys = Object.keys(require.extensions);
+function isValidExtension(ext, extensions) {
+  var keys = Object.keys(extensions || require.extensions);
   return keys.indexOf(ext) !== -1; 
 }


### PR DESCRIPTION
Updated README
Workaround for https://github.com/krakenjs/express-enrouten/issues/#92
--

Without this fix, I'm unable to use Jest to run web tests. In addition, Webpack & StandardJS will also end up complaining about using deprecated require.extensions.

There are better ways to handle this, but this is what works for now. I wasn't able to figure out what to change for test cases. Could use some help there.
