### PR TITLE
Feature: Support for Async Middleware

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -6,11 +6,9 @@ var express = require('express');
 var debug = require('debuglog')('enrouten/registry');
 var propertyExists = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
 
-
 function endsWith(str, chars) {
     return str.slice(-chars.length) === chars;
 }
-
 
 function removeSuffix(str, chars) {
     return endsWith(str, chars) ? str.slice(0, -chars.length) : str;
@@ -71,6 +69,29 @@ module.exports = function create(mountpath, router, options) {
         }
     });
 
+    // extend native server methods with promise support
+    makePromiseFriendly(registry);
+
     return registry;
 
 };
+
+function makePromiseFriendly(registry) {
+    let methods = ['use', 'get', 'post', 'delete', 'put', 'options', 'head', 'trace', 'connect'];
+    methods.forEach((method) => {
+        let oldMethod = registry[method].bind(registry);
+        registry[method] = (...routes) => {
+            oldMethod(...routes.map(makePromiseAware))
+        }
+    })
+}
+
+function makePromiseAware(m) {
+    if (Array.isArray(m)) return m.map(makePromiseAware)
+ 
+    // error handlers and strings are ignored
+    if (typeof m !== 'function' || m.length === 4) return m
+ 
+    // we can't test if we're using an async function or not, so let's make sure 
+    return (req, res, next) => Promise.resolve(m(req, res, next)).catch(next);
+}


### PR DESCRIPTION
Let's officially add support for async middleware / routes.

Does this by wrapping all routes at the enrouten level with a promise and catching errors and forwarding them to `next(err)`

Have been using this internally, but thought it might be cool to make it public. I'd suggest major bumping this and releasing it as a 2.0 enhancement, but outside of the use of the spread operator it should work in node 4+.

@aheckmann @snowinferno @shaunwarman 